### PR TITLE
Use transaction nonces when signing

### DIFF
--- a/estimator_test.go
+++ b/estimator_test.go
@@ -63,9 +63,8 @@ func TestEstimateSimpleSequenceTransaction(t *testing.T) {
 
 	txs := sequence.Transactions{
 		&sequence.Transaction{
-			To:    callmockContract.Address,
-			Data:  calldata,
-			Nonce: testChain.RandomNonce(),
+			To:   callmockContract.Address,
+			Data: calldata,
 		},
 	}
 
@@ -119,9 +118,8 @@ func TestEstimateSimpleSequenceTransactionNonDeployedWallet(t *testing.T) {
 
 	txs := sequence.Transactions{
 		&sequence.Transaction{
-			To:    callmockContract.Address,
-			Data:  calldata,
-			Nonce: testChain.RandomNonce(),
+			To:   callmockContract.Address,
+			Data: calldata,
 		},
 	}
 
@@ -185,9 +183,8 @@ func TestEstimateSimpleSequenceTransactionWithStubConfig(t *testing.T) {
 
 	txs := sequence.Transactions{
 		&sequence.Transaction{
-			To:    callmockContract.Address,
-			Data:  calldata,
-			Nonce: testChain.RandomNonce(),
+			To:   callmockContract.Address,
+			Data: calldata,
 		},
 	}
 
@@ -239,9 +236,8 @@ func TestEstimateSimpleSequenceTransactionWithBadNonce(t *testing.T) {
 
 	txs := sequence.Transactions{
 		&sequence.Transaction{
-			To:    callmockContract.Address,
-			Data:  calldata,
-			Nonce: testChain.RandomNonce(),
+			To:   callmockContract.Address,
+			Data: calldata,
 		},
 	}
 
@@ -292,18 +288,14 @@ func TestEstimateBatchSequenceTransaction(t *testing.T) {
 	calldata2, err := callmockContract.Encode("testCall", big.NewInt(6), ethcoder.MustHexDecode("0x223344"))
 	assert.NoError(t, err)
 
-	nonce := testChain.RandomNonce()
-
 	txs := sequence.Transactions{
 		&sequence.Transaction{
-			To:    callmockContract.Address,
-			Data:  calldata1,
-			Nonce: nonce,
+			To:   callmockContract.Address,
+			Data: calldata1,
 		},
 		&sequence.Transaction{
-			To:    callmockContract.Address,
-			Data:  calldata2,
-			Nonce: nonce,
+			To:   callmockContract.Address,
+			Data: calldata2,
 		},
 	}
 
@@ -393,9 +385,8 @@ func TestEstimateSequenceMultipleSigners(t *testing.T) {
 
 	txs := sequence.Transactions{
 		&sequence.Transaction{
-			To:    callmockContract.Address,
-			Data:  calldata,
-			Nonce: testChain.RandomNonce(),
+			To:   callmockContract.Address,
+			Data: calldata,
 		},
 	}
 

--- a/transactions.go
+++ b/transactions.go
@@ -73,6 +73,24 @@ func (t *Transaction) Bundle() Transactions {
 	return Transactions{t}
 }
 
+func (t Transactions) Nonce() (*big.Int, error) {
+	var cand *big.Int
+
+	for _, transaction := range t {
+		if transaction.Nonce != nil {
+			if cand == nil {
+				cand = new(big.Int).Set(transaction.Nonce)
+			} else {
+				if cand.Cmp(transaction.Nonce) != 0 {
+					return nil, fmt.Errorf("multiple nonces found")
+				}
+			}
+		}
+	}
+
+	return cand, nil
+}
+
 func (t *Transaction) IsValid() error {
 	// invariant 1: calldata and execdata are mutually exclusive
 	if t.Data != nil && (t.Transactions != nil || t.Nonce != nil || t.Signature != nil) {


### PR DESCRIPTION
- Use provided nonces when signing transactions
- Fail if conflicting nonces are provided
- Fallback to next nonce if no nonce is provided
- Remove custom nonces from tests (those where being ignored)