### PR TITLE
add support for json.Unmarshal

### DIFF
--- a/lib/prototyp/hash.go
+++ b/lib/prototyp/hash.go
@@ -49,6 +49,13 @@ func (h *Hash) UnmarshalText(src []byte) error {
 	return nil
 }
 
+// UnmarshalText implements json.Unmarshal.
+// Json Array of bytes
+func (h *Hash) UnmarshalJSON(src []byte) error {
+	*h = HashFromBytes(src)
+	return nil
+}
+
 func (h Hash) String() string {
 	return string(h)
 }


### PR DESCRIPTION
to help in unmarshalling of json objects having arrays of bytes with addresses like  
for example:
```json
[
	212,
	187,
	245,
	210,
	52,
	204,
	149,
	68,
	26,
	138,
	240,
	163,
	23,
	216,
	135,
	78,
	228,
	37,
	231,
	77
]
```
