### PR TITLE
receipt listener: fix goroutine leak

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/0xsequence/go-sequence
 go 1.16
 
 require (
-	github.com/0xsequence/ethkit v1.11.1
+	github.com/0xsequence/ethkit v1.12.3
 	github.com/0xsequence/go-ethauth v0.11.0
 	github.com/deckarep/golang-set v1.8.0 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2k
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/0xsequence/ethkit v1.11.0/go.mod h1:cyPNqgfJPwKgG7iXI9p6cBgIgxdPN2eh+FmeBU9EvTI=
-github.com/0xsequence/ethkit v1.11.1 h1:Isd+0MEq0amnzJz4PJWIxOxcTID5AKiHIPLhlBoQrPU=
-github.com/0xsequence/ethkit v1.11.1/go.mod h1:cyPNqgfJPwKgG7iXI9p6cBgIgxdPN2eh+FmeBU9EvTI=
+github.com/0xsequence/ethkit v1.12.3 h1:syw6X/JCHZcbhFpAcwQtDNlW2+RcZ7pDeA6O74ppKUE=
+github.com/0xsequence/ethkit v1.12.3/go.mod h1:cyPNqgfJPwKgG7iXI9p6cBgIgxdPN2eh+FmeBU9EvTI=
 github.com/0xsequence/go-ethauth v0.11.0 h1:m8VOiNRKrA1v5ArUgmJe+ESiDiNrnG35fjnm1pNCDdQ=
 github.com/0xsequence/go-ethauth v0.11.0/go.mod h1:b35SVvB9AkRCZaMFGiYW+uxR//st3SU1xtxw0b7N7Z0=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/receipt_listener.go
+++ b/receipt_listener.go
@@ -158,12 +158,13 @@ func (l *ReceiptListener) WaitForMetaTxn(ctx context.Context, metaTxnID MetaTxnI
 			}
 			done = true
 
-		case <-sub.done:
-			done = true
-
-		case r := <-sub.ch:
-			if r.MetaTxnID == metaTxnID {
-				receipt = &r
+		case r, ok := <-sub.ch:
+			if ok {
+				if r.MetaTxnID == metaTxnID {
+					receipt = &r
+					done = true
+				}
+			} else {
 				done = true
 			}
 		}


### PR DESCRIPTION
The makeUnboundedBuffered goroutine only exits once the consumer has consumed all messages in the output channel. So instead of waiting on the done channel in WaitForMetaTxn (which will potentially leave unread messages), we instead rely on the open/close state of the subscription channel to see if we are finished or not.