### PR TITLE
receipt listener: actually fix goroutine leak

### DIFF
--- a/receipt_listener.go
+++ b/receipt_listener.go
@@ -156,6 +156,11 @@ func (l *ReceiptListener) WaitForMetaTxn(ctx context.Context, metaTxnID MetaTxnI
 			} else if ctx.Err() != nil {
 				err = fmt.Errorf("failed waiting for meta transaction for %v: %w", metaTxnID, ctx.Err())
 			}
+
+			// flush subscriber.ch so that the makeUnboundedBuffered goroutine exits
+			for ok := true; ok; _, ok = <-sub.ch {
+			}
+
 			done = true
 
 		case r, ok := <-sub.ch:


### PR DESCRIPTION
Another missed case: If ctx.Done() is closed, then we actually don't end up flushing the unbounded buffered channel. So we need to manually drain it in the context cancellation case.