### PR TITLE
Compressor fixes

### DIFF
--- a/compressor/compressor.go
+++ b/compressor/compressor.go
@@ -206,8 +206,8 @@ func (cm *Compressor) IsSaneCompression(
 		return fmt.Errorf("exec data does not match input")
 	}
 
-	if !bytes.Equal(decompressed, ed2) {
-		return fmt.Errorf("exec data does not match input")
+	if !bytes.Equal(decompressed, ed2) && !bytes.Equal(decompressed, ed1) {
+		return fmt.Errorf("decompressed exec data does not match input")
 	}
 
 	return nil


### PR DESCRIPTION
- Compare decompressed result with mutated **and** original
- Skip signature compression unless contract storage is used