### PR TITLE
4318: prototyp.BigInt: fix int64 parsing overflow

### DIFF
--- a/lib/prototyp/bigint.go
+++ b/lib/prototyp/bigint.go
@@ -3,8 +3,8 @@ package prototyp
 import (
 	"database/sql/driver"
 	"fmt"
+	"math"
 	"math/big"
-	"strconv"
 	"strings"
 )
 
@@ -47,13 +47,15 @@ func NewBigIntFromString(s string, base int) BigInt {
 		return BigInt{}
 	}
 
+	var bi BigInt
 	b, ok := b.SetString(s, base)
-	if !ok {
-		n, _ := ParseNumberString(s, base)
-		b = big.NewInt(n)
+	if ok {
+		bi = BigInt(*b)
+	} else {
+		bi, _ = ParseBigIntString(s, base)
 	}
 
-	return BigInt(*b)
+	return bi
 }
 
 func ToBigInt(b *big.Int) BigInt {
@@ -244,7 +246,7 @@ func (b *BigInt) UnmarshalBinary(buff []byte) error {
 	return b.UnmarshalText(buff)
 }
 
-func ParseNumberString(s string, base int) (int64, bool) {
+func ParseBigIntString(s string, base int) (BigInt, bool) {
 	var ns strings.Builder
 	switch base {
 	case 2:
@@ -290,15 +292,30 @@ func ParseNumberString(s string, base int) (int64, bool) {
 		s = strings.TrimPrefix(s, "0X")
 		s = strings.TrimPrefix(s, "0x")
 	default:
+		return BigInt{}, false
+	}
+
+	b := big.NewInt(0)
+	b, ok := b.SetString(s, base)
+	if !ok {
+		return BigInt{}, false
+	}
+
+	return BigInt(*b), true
+}
+
+func ParseNumberString(s string, base int) (int64, bool) {
+	bi, ok := ParseBigIntString(s, base)
+	if !ok {
 		return 0, false
 	}
 
-	n, err := strconv.ParseInt(s, base, 64)
-	if err != nil {
+	// Check if it fits within int64 range, if it doesn't fit in int64, return false
+	if bi.Lt(big.NewInt(math.MinInt64)) || bi.Gt(big.NewInt(math.MaxInt64)) {
 		return 0, false
 	}
 
-	return n, true
+	return bi.Int64(), true
 }
 
 func IsValidNumberString(s string) bool {

--- a/lib/prototyp/bigint.go
+++ b/lib/prototyp/bigint.go
@@ -247,6 +247,7 @@ func (b *BigInt) UnmarshalBinary(buff []byte) error {
 }
 
 func ParseBigIntString(s string, base int) (BigInt, bool) {
+	neg := strings.HasPrefix(s, "-")
 	var ns strings.Builder
 	switch base {
 	case 2:
@@ -293,6 +294,10 @@ func ParseBigIntString(s string, base int) (BigInt, bool) {
 		s = strings.TrimPrefix(s, "0x")
 	default:
 		return BigInt{}, false
+	}
+
+	if neg {
+		s = "-" + s
 	}
 
 	b := big.NewInt(0)

--- a/lib/prototyp/bigint_test.go
+++ b/lib/prototyp/bigint_test.go
@@ -2,7 +2,10 @@ package prototyp
 
 import (
 	"encoding/json"
+	"fmt"
+	"math"
 	"math/big"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -96,6 +99,82 @@ func TestBigIntFromBaseString(t *testing.T) {
 			b := tc.fn(tc.input)
 			assert.Equal(t, tc.expected, b.String())
 		})
+	}
+}
+
+func TestNumberFromBaseString(t *testing.T) {
+	type testCase struct {
+		input       string
+		expectedInt int64
+		expectedOk  bool
+	}
+
+	tests := []struct {
+		base  int
+		cases []testCase
+	}{
+		{
+			base: 2,
+			cases: []testCase{
+				{"00101010", 42, true},
+				{"-00101010", -42, true},
+				{"0B00101010", 42, true},
+				{"0b00101010", 42, true},
+				{strconv.FormatInt(math.MaxInt64, 2), math.MaxInt64, true},
+				{strconv.FormatInt(math.MaxInt64, 2) + "0", 0, false},
+				{strconv.FormatInt(math.MinInt64, 2), math.MinInt64, true},
+				{strconv.FormatInt(math.MinInt64, 2) + "0", 0, false},
+			},
+		},
+		{
+			base: 8,
+			cases: []testCase{
+				{"52", 42, true},
+				{"-52", -42, true},
+				{"0O52", 42, true},
+				{"0o52", 42, true},
+				{strconv.FormatInt(math.MaxInt64, 8), math.MaxInt64, true},
+				{strconv.FormatInt(math.MaxInt64, 8) + "0", 0, false},
+				{strconv.FormatInt(math.MinInt64, 8), math.MinInt64, true},
+				{strconv.FormatInt(math.MinInt64, 8) + "0", 0, false},
+			},
+		},
+		{
+			base: 10,
+			cases: []testCase{
+				{"42", 42, true},
+				{"-42", -42, true},
+				{strconv.FormatInt(math.MaxInt64, 10), math.MaxInt64, true},
+				{strconv.FormatInt(math.MaxInt64, 10) + "0", 0, false},
+				{strconv.FormatInt(math.MinInt64, 10), math.MinInt64, true},
+				{strconv.FormatInt(math.MinInt64, 10) + "0", 0, false},
+			},
+		},
+		{
+			base: 16,
+			cases: []testCase{
+				{"2A", 42, true},
+				{"2a", 42, true},
+				{"-2A", -42, true},
+				{"-2a", -42, true},
+				{"0x2a", 42, true},
+				{"0X2a", 42, true},
+				{strconv.FormatInt(math.MaxInt64, 16), math.MaxInt64, true},
+				{strconv.FormatInt(math.MaxInt64, 16) + "0", 0, false},
+				{strconv.FormatInt(math.MinInt64, 16), math.MinInt64, true},
+				{strconv.FormatInt(math.MinInt64, 16) + "0", 0, false},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		for _, tc := range tt.cases {
+			t.Run(fmt.Sprintf("%d_%s", tt.base, tc.input), func(t *testing.T) {
+				i, ok := ParseNumberString(tc.input, tt.base)
+				assert.Equal(t, tc.expectedInt, i)
+				assert.Equal(t, tc.expectedOk, ok)
+			})
+		}
 	}
 }
 

--- a/lib/prototyp/bigint_test.go
+++ b/lib/prototyp/bigint_test.go
@@ -61,38 +61,40 @@ func TestBigIntFromBaseString(t *testing.T) {
 	testCases := []struct {
 		fn       func(string) BigInt
 		input    string
-		expected int64
+		expected string
 		testName string
 	}{
 		// Binary tests
-		{NewBigIntFromBinaryString, "00101010", 42, "Binary 42"},
-		{NewBigIntFromBinaryString, "-00101010", -42, "Binary -42"},
-		{NewBigIntFromBinaryString, "0B00101010", 42, "Binary with 0B 42"},
-		{NewBigIntFromBinaryString, "0b00101010", 42, "Binary with 0b 42"},
+		{NewBigIntFromBinaryString, "00101010", "42", "Binary 42"},
+		{NewBigIntFromBinaryString, "-00101010", "-42", "Binary -42"},
+		{NewBigIntFromBinaryString, "0B00101010", "42", "Binary with 0B 42"},
+		{NewBigIntFromBinaryString, "0b00101010", "42", "Binary with 0b 42"},
+		{NewBigIntFromBinaryString, "111111111111111111111111111111111111111111111111111111111111111111111111", "4722366482869645213695", "Binary with 0b 42"},
 
 		// Octal tests
-		{NewBigIntFromOctalString, "52", 42, "Octal 42"},
-		{NewBigIntFromOctalString, "-52", -42, "Octal -42"},
-		{NewBigIntFromOctalString, "0O52", 42, "Octal with 0O 42"},
-		{NewBigIntFromOctalString, "0o52", 42, "Octal with 0o 42"},
+		{NewBigIntFromOctalString, "52", "42", "Octal 42"},
+		{NewBigIntFromOctalString, "-52", "-42", "Octal -42"},
+		{NewBigIntFromOctalString, "0O52", "42", "Octal with 0O 42"},
+		{NewBigIntFromOctalString, "0o52", "42", "Octal with 0o 42"},
 
 		// Decimal tests
-		{NewBigIntFromDecimalString, "42", 42, "Decimal 42"},
-		{NewBigIntFromDecimalString, "-42", -42, "Decimal -42"},
+		{NewBigIntFromDecimalString, "42", "42", "Decimal 42"},
+		{NewBigIntFromDecimalString, "-42", "-42", "Decimal -42"},
 
 		// Hexadecimal tests
-		{NewBigIntFromHexString, "2A", 42, "Hex 2A"},
-		{NewBigIntFromHexString, "2a", 42, "Hex 2a"},
-		{NewBigIntFromHexString, "-2A", -42, "Hex -2A"},
-		{NewBigIntFromHexString, "-2a", -42, "Hex -2a"},
-		{NewBigIntFromHexString, "0x2a", 42, "Hex with 0x 42"},
-		{NewBigIntFromHexString, "0X2a", 42, "Hex with 0X 42"},
+		{NewBigIntFromHexString, "2A", "42", "Hex 2A"},
+		{NewBigIntFromHexString, "2a", "42", "Hex 2a"},
+		{NewBigIntFromHexString, "-2A", "-42", "Hex -2A"},
+		{NewBigIntFromHexString, "-2a", "-42", "Hex -2a"},
+		{NewBigIntFromHexString, "0x2a", "42", "Hex with 0x 42"},
+		{NewBigIntFromHexString, "0X2a", "42", "Hex with 0X 42"},
+		{NewBigIntFromHexString, "0x029a2241af62c000c8", "48000000000000000200", "Hex with 0x029a2241af62c000c8 48000000000000000200"},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
 			b := tc.fn(tc.input)
-			assert.Equal(t, tc.expected, b.Int64())
+			assert.Equal(t, tc.expected, b.String())
 		})
 	}
 }


### PR DESCRIPTION
Ticket: https://github.com/0xsequence/issue-tracker/issues/4318

Previously, parsing a string into `BigInt` would silently return 0 on overflow of int64 without any warning. This fix ensures that numbers larger than `int64` are correctly parsed instead of returning 0, because of overflow.

Also added handling of negative numbers and tests to cover edge cases related to `int64` parsing.