### PR TITLE
prototyp: binary marshal fix, prepend pos/neg sign for bigint

### DIFF
--- a/lib/prototyp/bigint.go
+++ b/lib/prototyp/bigint.go
@@ -198,13 +198,17 @@ func (b *BigInt) UnmarshalJSON(text []byte) error {
 // MarshalBinary implements encoding.BinaryMarshaler. The first byte is the sign byte
 // to represent positive or negative numbers.
 func (b BigInt) MarshalBinary() ([]byte, error) {
+	bytes := b.Int().Bytes()
+	out := make([]byte, len(bytes)+1)
+	copy(out[1:], bytes)
 	if b.Int().Sign() < 0 {
 		// Prepend a sign byte (0xFF for negative)
-		return append([]byte{0xFF}, b.Int().Bytes()...), nil
+		out[0] = 0xFF
 	} else {
 		// For zero or positive numbers, prepend 0x00
-		return append([]byte{0x00}, b.Int().Bytes()...), nil
+		out[0] = 0x00
 	}
+	return out, nil
 }
 
 // UnmarshalBinary implements encoding.BinaryUnmarshaler. The first byte is the sign byte
@@ -217,10 +221,11 @@ func (b *BigInt) UnmarshalBinary(buff []byte) error {
 
 	// Extract the sign byte
 	signByte := buff[0]
-	valueBytes := buff[1:]
 
-	// Create big.Int from the value bytes
-	i := big.NewInt(0).SetBytes(valueBytes)
+	i := new(big.Int)
+	if len(buff) > 1 {
+		i.SetBytes(buff[1:])
+	}
 
 	// Apply sign if negative
 	if signByte == 0xFF {

--- a/lib/prototyp/bigint_test.go
+++ b/lib/prototyp/bigint_test.go
@@ -30,17 +30,33 @@ func TestBigIntJSONMarshalling(t *testing.T) {
 }
 
 func TestBigIntBinaryMarshalling(t *testing.T) {
-	b := NewBigInt(123)
-	data, err := b.MarshalBinary()
-	require.NoError(t, err)
-	require.Equal(t, []byte{123}, data)
-	require.Equal(t, "123", b.String())
+	{
+		b := NewBigInt(123)
+		data, err := b.MarshalBinary()
+		require.NoError(t, err)
+		require.Equal(t, []byte{0x00, 123}, data)
+		require.Equal(t, "123", b.String())
 
-	var b2 BigInt
-	err = b2.UnmarshalBinary(data)
-	require.NoError(t, err)
-	require.Equal(t, b, b2)
-	require.Equal(t, "123", b2.String())
+		var b2 BigInt
+		err = b2.UnmarshalBinary(data)
+		require.NoError(t, err)
+		require.Equal(t, b, b2)
+		require.Equal(t, "123", b2.String())
+	}
+
+	{
+		b := NewBigInt(-123)
+		data, err := b.MarshalBinary()
+		require.NoError(t, err)
+		require.Equal(t, []byte{0xFF, 123}, data)
+		require.Equal(t, "-123", b.String())
+
+		var b2 BigInt
+		err = b2.UnmarshalBinary(data)
+		require.NoError(t, err)
+		require.Equal(t, b, b2)
+		require.Equal(t, "-123", b2.String())
+	}
 }
 
 func TestBigIntValue(t *testing.T) {
@@ -53,6 +69,11 @@ func TestBigIntValue(t *testing.T) {
 	assert.True(t, ok)
 
 	assert.Equal(t, int64(123), b2.Int64())
+}
+
+func TestBigIntNegative(t *testing.T) {
+	b := NewBigInt(-1)
+	require.Equal(t, "-1", b.String())
 }
 
 func TestBigIntAdd(t *testing.T) {


### PR DESCRIPTION
the .Int().Bytes() was incorrectly dropping the sign of the number, as it doesn't have its own default encoding, so its up to us to decide how to encode the sign into the byte array. This PR solves it.