### PR TITLE
Add test for testutil.TestNewTestChain() with options

### DIFF
--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -2,6 +2,7 @@ package testutil_test
 
 import (
 	"math/big"
+	"os"
 	"testing"
 
 	"github.com/0xsequence/ethkit/ethcoder"
@@ -78,4 +79,20 @@ func TestContractHelpers(t *testing.T) {
 	_, err = testutil.ContractCall(testChain.Provider, callmockContract.Address, callmockContract.ABI, &result, "lastValA")
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(143), result.Uint64())
+}
+
+func TestNewTestChainWithOptions(t *testing.T) {
+	opt := testutil.DefaultTestChainOptions
+	if nodeURL, ok := os.LookupEnv("CHAIN_NODE_URL"); ok {
+		opt = testutil.TestChainOptions{
+			NodeURL: nodeURL,
+		}
+	}
+	testChain, err := testutil.NewTestChain(opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := testChain.Connect(); err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
Add test for this error I encountered in the stack/api repo:

```
# github.com/0xsequence/go-sequence/testutil
../../../../go/pkg/mod/github.com/0xsequence/go-sequence@v0.55.0/testutil/testutil.go:91:51:
   cannot use logger.NewLogger(logger.LogLevel_INFO) (value of interface type logger.Logger) as *slog.Logger value in argument to ethreceipts.NewReceiptsListener
```

Unfortunately, I think this won't prove/fix the root cause -- I think I'll need to upgrade ethkit.