### PR TITLE
v3: add pending updates to wallet config

### DIFF
--- a/core/v3/v3.go
+++ b/core/v3/v3.go
@@ -42,12 +42,13 @@ func (v3Core) DecodeSignature(data []byte) (core.Signature[*WalletConfig], error
 	}
 
 	signatureFlag := data[0]
-	data = data[1:]
 
 	signatureType := signatureFlag & 0x03
 	if signatureType == 0x01 {
 		return decodeChainedSignature(data)
 	}
+
+	data = data[1:]
 
 	noChainId := (signatureType & 0x02) == 0x02
 
@@ -1316,7 +1317,6 @@ func (l signatureTreeSubdigestLeaf) reduceImageHash() (core.ImageHash, error) {
 
 func (l signatureTreeSubdigestLeaf) write(writer io.Writer) error {
 	_, err := writer.Write([]byte{FLAG_SUBDIGEST << 4})
-
 	if err != nil {
 		return fmt.Errorf("unable to write subdigest leaf type: %w", err)
 	}
@@ -1556,6 +1556,7 @@ func (l *signatureTreeSignatureEthSignLeaf) reduce() signatureTree { return l }
 func (l *signatureTreeSignatureEthSignLeaf) join(other signatureTree) (signatureTree, error) {
 	return l, nil
 }
+
 func (l *signatureTreeSignatureEthSignLeaf) reduceImageHash() (core.ImageHash, error) {
 	return core.ImageHash{}, fmt.Errorf("eth sign signature has signing power")
 }
@@ -1906,6 +1907,8 @@ type WalletConfig struct {
 	Checkpoint_  uint64           `json:"checkpoint" toml:"checkpoint"`
 	Tree         WalletConfigTree `json:"tree" toml:"tree"`
 	Checkpointer common.Address   `json:"checkpointer,omitempty" toml:"checkpointer,omitempty"`
+
+	PendingUpdates []core.Signature[*WalletConfig] `json:"-" toml:"-"`
 }
 
 func (c *WalletConfig) Threshold() uint16 {

--- a/utils.go
+++ b/utils.go
@@ -58,6 +58,10 @@ func DeploySequenceWallet(sender *ethwallet.Wallet, walletConfig core.WalletConf
 
 func EncodeWalletDeployment(walletConfig core.WalletConfig, walletContext WalletContext) (common.Address, common.Address, []byte, error) {
 	imageHash := walletConfig.ImageHash()
+	return EncodeWalletDeploymentWithImageHash(walletConfig, walletContext, imageHash)
+}
+
+func EncodeWalletDeploymentWithImageHash(walletConfig core.WalletConfig, walletContext WalletContext, imageHash core.ImageHash) (common.Address, common.Address, []byte, error) {
 	address, err := AddressFromImageHash(imageHash, walletContext)
 	if err != nil {
 		return common.Address{}, common.Address{}, nil, err

--- a/wallet.go
+++ b/wallet.go
@@ -863,6 +863,10 @@ func (w *Wallet[C]) IsDeployed() (bool, error) {
 }
 
 func (w *Wallet[C]) Deploy(ctx context.Context, transactions ...*Transaction) (MetaTxnID, *types.Transaction, ethtxn.WaitReceipt, error) {
+	return w.DeployWithImageHash(ctx, w.config.ImageHash(), transactions...)
+}
+
+func (w *Wallet[C]) DeployWithImageHash(ctx context.Context, imageHash core.ImageHash, transactions ...*Transaction) (MetaTxnID, *types.Transaction, ethtxn.WaitReceipt, error) {
 	if w.relayer == nil {
 		return "", nil, nil, ErrRelayerNotSet
 	}

--- a/wallet.go
+++ b/wallet.go
@@ -876,7 +876,7 @@ func (w *Wallet[C]) DeployWithImageHash(ctx context.Context, imageHash core.Imag
 		return "", nil, nil, fmt.Errorf("already deployed")
 	}
 
-	walletAddress, walletFactoryAddress, deploymentData, err := EncodeWalletDeployment(w.config, w.context)
+	walletAddress, walletFactoryAddress, deploymentData, err := EncodeWalletDeploymentWithImageHash(w.config, w.context, imageHash)
 	if err != nil {
 		return "", nil, nil, err
 	}

--- a/wallet.go
+++ b/wallet.go
@@ -108,7 +108,7 @@ func GenericNewWalletSingleOwner[C core.WalletConfig](owner Signer, optContext .
 	if _, ok := core.WalletConfig(typeOfWallet).(*v1.WalletConfig); ok {
 		// new wallet config v1
 		var config core.WalletConfig = &v1.WalletConfig{
-			Threshold_: 1, //big.NewInt(1),
+			Threshold_: 1, // big.NewInt(1),
 			Signers_: v1.WalletConfigSigners{
 				{Weight: 1, Address: owner.Address()},
 			},
@@ -122,7 +122,7 @@ func GenericNewWalletSingleOwner[C core.WalletConfig](owner Signer, optContext .
 	} else if _, ok := core.WalletConfig(typeOfWallet).(*v2.WalletConfig); ok {
 		// new wallet config v2
 		var config core.WalletConfig = &v2.WalletConfig{
-			Threshold_: 1, //big.NewInt(1),
+			Threshold_: 1, // big.NewInt(1),
 			Tree: &v2.WalletConfigTreeAddressLeaf{
 				Weight: 1, Address: owner.Address(),
 			},
@@ -136,7 +136,7 @@ func GenericNewWalletSingleOwner[C core.WalletConfig](owner Signer, optContext .
 	} else if _, ok := core.WalletConfig(typeOfWallet).(*v3.WalletConfig); ok {
 		// new wallet config v3
 		var config core.WalletConfig = &v3.WalletConfig{
-			Threshold_: 1, //big.NewInt(1),
+			Threshold_: 1, // big.NewInt(1),
 			Tree: &v3.WalletConfigTreeAddressLeaf{
 				Weight: 1, Address: owner.Address(),
 			},
@@ -260,7 +260,6 @@ func (w *Wallet[C]) UseConfig(config C) (*Wallet[C], error) {
 		SkipSortSigners: w.skipSortSigners,
 		Address:         w.address,
 	})
-
 	if err != nil {
 		return nil, fmt.Errorf("sequence.Wallet#UseConfig: %w", err)
 	}
@@ -286,7 +285,6 @@ func (w *Wallet[C]) UseSigners(signers ...Signer) (*Wallet[C], error) {
 		SkipSortSigners: w.skipSortSigners,
 		Address:         w.address,
 	})
-
 	if err != nil {
 		return nil, fmt.Errorf("sequence.Wallet#UseSigners: %w", err)
 	}
@@ -485,9 +483,11 @@ func (w *Wallet[C]) SignTypedData(typedData *ethcoder.TypedData) ([]byte, []byte
 	return signature, encodedTypedData, nil
 }
 
-var _ MessageSigner = (*Wallet[*v1.WalletConfig])(nil)
-var _ MessageSigner = (*Wallet[*v2.WalletConfig])(nil)
-var _ MessageSigner = (*Wallet[*v3.WalletConfig])(nil)
+var (
+	_ MessageSigner = (*Wallet[*v1.WalletConfig])(nil)
+	_ MessageSigner = (*Wallet[*v2.WalletConfig])(nil)
+	_ MessageSigner = (*Wallet[*v3.WalletConfig])(nil)
+)
 
 func (w *Wallet[C]) SignDigest(ctx context.Context, digest common.Hash, optChainID ...*big.Int) ([]byte, error) {
 	if w.sessions != nil {
@@ -612,8 +612,10 @@ func (w *Wallet[C]) SignV3Payload(ctx context.Context, payload core.Payload, opt
 	return res, sig, err
 }
 
-var _ DigestSigner = (*Wallet[*v1.WalletConfig])(nil)
-var _ DigestSigner = (*Wallet[*v2.WalletConfig])(nil)
+var (
+	_ DigestSigner = (*Wallet[*v1.WalletConfig])(nil)
+	_ DigestSigner = (*Wallet[*v2.WalletConfig])(nil)
+)
 
 func (w *Wallet[C]) SignTransaction(ctx context.Context, txn *Transaction) (*SignedTransactions, error) {
 	return w.SignTransactions(ctx, Transactions{txn})
@@ -1044,6 +1046,10 @@ func (w *Wallet[C]) buildSignature(ctx context.Context, sign core.SigningFunctio
 			if err != nil {
 				return nil, nil, fmt.Errorf("SignDigest, BuildRegularSignature: %w", err)
 			}
+		}
+
+		if len(config.PendingUpdates) > 0 {
+			sig = append(v3.ChainedSignature{sig}, config.PendingUpdates...)
 		}
 
 		sigEnc, err := sig.Data()


### PR DESCRIPTION
When `WalletConfig`s `PendingUpdates` (set by the caller) is not empty, `buildSignature` turns the `sig` into a `ChainedSignature{sig}` and appends the pending updates to it.