### PR TITLE
Move path to abicalldata

### DIFF
--- a/lib/abicalldata/README.md
+++ b/lib/abicalldata/README.md
@@ -1,6 +1,6 @@
 # ABI calldata
 
-Helpers for **Ethereum ABI-encoded calldata**: head layout, static argument words, and dynamic `bytes`/`string` tails. Also defines **`ByteRange`** and **`Selector`** for locating byte spans inside a v3 **`CallsPayload`**.
+Helpers for **Ethereum ABI-encoded calldata**: head layout, static argument words, and dynamic `bytes`/`string` tails. Also defines **`ByteRange`**, **`Selector`**, and a fluent **`Path`** for locating byte spans inside a v3 **`CallsPayload`**.
 
 ## Calldata layout
 
@@ -33,4 +33,35 @@ sel := abicalldata.NewRangeSelector(0, 0x24, 32)
 ranges, err := sel.Resolve(payload)
 ```
 
-**`Selector`** is implemented by types in other packages that walk `CallsPayload` and nested calldata; they typically use the functions above to turn `abi.Method` + argument index into `ByteRange` updates. **`NewRangeSelector`** is the built-in implementation for a fixed call index, offset, and length.
+## Path builder (`NewPath`)
+
+**`*Path`** is a **`Selector`**: chain steps to walk from a top-level call into nested packed calls and ABI argument slots, then call **`.AsSelector()`** for APIs that take a **`Selector`**.
+
+Typical steps:
+
+- **`.CallData(i)`** — start from `payload.Calls[i].Data`.
+- **`.ABI(contractABI, method)`** — bind the current range to that method (checks the 4-byte selector).
+- **`.ArgSlot(name)`** / **`.ArgSlotIndex(i)`** — static argument word(s) in the current frame.
+- **`.ArgBytesData(name)`** / **`.ArgBytesDataIndex(i)`** — inner payload of a `bytes`/`string` argument (clears ABI context; rebind with `.ABI` before further arg steps).
+- **`.ArgBytesEncoded(name)`** — full ABI-encoded tail for that dynamic argument.
+- **`.EncodedCallsPayload()`** — treat the active range as v3 packed calls; clear ABI context.
+- **`.EncodedCallData(j)`** — select packed call `j`’s calldata within that layout.
+- **`.Slice(offset, size)`** — byte slice within the active range.
+
+```go
+sel := abicalldata.NewPath().
+    CallData(0).
+    ABI(&outerABI, "hydrateExecute").
+    ArgBytesData("payload").
+    EncodedCallsPayload().
+    EncodedCallData(0).
+    ABI(&tokenABI, "permit").
+    ArgSlot("value").
+    AsSelector()
+```
+
+After any step that narrows the range or switches to a new byte frame (including **`.Slice`**, **`.ArgBytesData`**, **`.ArgBytesDataIndex`**, **`.ArgBytesEncoded`**, **`.EncodedCallsPayload`**, **`.EncodedCallData`**), ABI context is cleared. Call **`.ABI(...)`** again before **`.ArgSlot`**, **`.ArgSlotIndex`**, **`.ArgBytesData`**, **`.ArgBytesDataIndex`**, or **`.ArgBytesEncoded`** on the new frame.
+
+## Packed calls layout
+
+**`ParsePackedCalls(packed []byte)`** returns a **`PackedCallsLayout`** describing where each call’s calldata sits inside the encoded packed-calls blob (as produced by `CallsPayload.Encode`). **`CallData`** entries use **`Span`** (`Start`, `Len`; `Start == -1` when that call has no calldata). The path step **`.EncodedCallData(i)`** uses this parser internally.

--- a/lib/abicalldata/packedcalls.go
+++ b/lib/abicalldata/packedcalls.go
@@ -1,4 +1,4 @@
-package malleable
+package abicalldata
 
 import (
 	"encoding/binary"

--- a/lib/abicalldata/packedcalls_test.go
+++ b/lib/abicalldata/packedcalls_test.go
@@ -1,4 +1,4 @@
-package malleable
+package abicalldata
 
 import (
 	"math/big"

--- a/lib/abicalldata/path.go
+++ b/lib/abicalldata/path.go
@@ -1,4 +1,4 @@
-package malleable
+package abicalldata
 
 import (
 	"fmt"
@@ -7,8 +7,6 @@ import (
 
 	"github.com/0xsequence/ethkit/go-ethereum/accounts/abi"
 	v3 "github.com/0xsequence/go-sequence/core/v3"
-
-	"github.com/0xsequence/go-sequence/lib/abicalldata"
 )
 
 type Path struct {
@@ -80,11 +78,11 @@ func (p *Path) EncodedCallData(i int) *Path {
 	return p
 }
 
-func (p *Path) AsSelector() abicalldata.Selector {
+func (p *Path) AsSelector() Selector {
 	return p
 }
 
-func (p *Path) Resolve(payload *v3.CallsPayload) ([]abicalldata.ByteRange, error) {
+func (p *Path) Resolve(payload *v3.CallsPayload) ([]ByteRange, error) {
 	state := pathState{}
 	for _, step := range p.steps {
 		if err := step.apply(payload, &state); err != nil {
@@ -105,13 +103,13 @@ func (p *Path) String() string {
 }
 
 type pathState struct {
-	ranges []abicalldata.ByteRange
+	ranges []ByteRange
 	// method only applies to the current full calldata frame. Any step that
 	// narrows or reinterprets the active range must clear it.
 	method *abi.Method
 }
 
-func (s *pathState) replaceRanges(ranges []abicalldata.ByteRange) {
+func (s *pathState) replaceRanges(ranges []ByteRange) {
 	s.ranges = ranges
 	s.method = nil
 }
@@ -135,8 +133,8 @@ type pathStep interface {
 	apply(payload *v3.CallsPayload, state *pathState) error
 }
 
-func mapRanges(ranges []abicalldata.ByteRange, fn func(abicalldata.ByteRange) (abicalldata.ByteRange, error)) ([]abicalldata.ByteRange, error) {
-	out := make([]abicalldata.ByteRange, 0, len(ranges))
+func mapRanges(ranges []ByteRange, fn func(ByteRange) (ByteRange, error)) ([]ByteRange, error) {
+	out := make([]ByteRange, 0, len(ranges))
 	for _, r := range ranges {
 		next, err := fn(r)
 		if err != nil {
@@ -158,7 +156,7 @@ func (s callDataStep) apply(payload *v3.CallsPayload, state *pathState) error {
 	if s.index < 0 || s.index >= len(payload.Calls) {
 		return fmt.Errorf("call index out of range: %d", s.index)
 	}
-	state.replaceRanges([]abicalldata.ByteRange{{
+	state.replaceRanges([]ByteRange{{
 		CallIndex: s.index,
 		Offset:    0,
 		Size:      len(payload.Calls[s.index].Data),
@@ -175,17 +173,17 @@ func (s sliceStep) apply(payload *v3.CallsPayload, state *pathState) error {
 	if len(state.ranges) == 0 {
 		return fmt.Errorf("slice step has no active ranges")
 	}
-	out, err := mapRanges(state.ranges, func(r abicalldata.ByteRange) (abicalldata.ByteRange, error) {
+	out, err := mapRanges(state.ranges, func(r ByteRange) (ByteRange, error) {
 		if s.offset < 0 || s.size < 0 {
-			return abicalldata.ByteRange{}, fmt.Errorf("slice offset/size negative: %d, %d", s.offset, s.size)
+			return ByteRange{}, fmt.Errorf("slice offset/size negative: %d, %d", s.offset, s.size)
 		}
 		if s.size > r.Size || s.offset > r.Size-s.size {
-			return abicalldata.ByteRange{}, fmt.Errorf("slice out of bounds: offset=%d size=%d within %d", s.offset, s.size, r.Size)
+			return ByteRange{}, fmt.Errorf("slice out of bounds: offset=%d size=%d within %d", s.offset, s.size, r.Size)
 		}
 		if s.offset > math.MaxInt-r.Offset {
-			return abicalldata.ByteRange{}, fmt.Errorf("slice offset overflow with range")
+			return ByteRange{}, fmt.Errorf("slice offset overflow with range")
 		}
-		return abicalldata.ByteRange{
+		return ByteRange{
 			CallIndex: r.CallIndex,
 			Offset:    r.Offset + s.offset,
 			Size:      s.size,
@@ -250,15 +248,15 @@ func (s argSlotStep) apply(payload *v3.CallsPayload, state *pathState) error {
 	if isDynamicType(argType) {
 		return fmt.Errorf("arg %s is dynamic (%s)", s.name, argType.String())
 	}
-	start, length, err := abicalldata.CalldataStaticWord(method, argIndex)
+	start, length, err := CalldataStaticWord(method, argIndex)
 	if err != nil {
 		return err
 	}
-	out, err := mapRanges(state.ranges, func(r abicalldata.ByteRange) (abicalldata.ByteRange, error) {
+	out, err := mapRanges(state.ranges, func(r ByteRange) (ByteRange, error) {
 		if start+length > r.Size {
-			return abicalldata.ByteRange{}, fmt.Errorf("arg slot out of bounds for %s", s.name)
+			return ByteRange{}, fmt.Errorf("arg slot out of bounds for %s", s.name)
 		}
-		return abicalldata.ByteRange{
+		return ByteRange{
 			CallIndex: r.CallIndex,
 			Offset:    r.Offset + start,
 			Size:      length,
@@ -288,15 +286,15 @@ func (s argSlotIndexStep) apply(payload *v3.CallsPayload, state *pathState) erro
 	if isDynamicType(argType) {
 		return fmt.Errorf("arg %d is dynamic (%s)", argIndex, argType.String())
 	}
-	start, length, err := abicalldata.CalldataStaticWord(method, argIndex)
+	start, length, err := CalldataStaticWord(method, argIndex)
 	if err != nil {
 		return err
 	}
-	out, err := mapRanges(state.ranges, func(r abicalldata.ByteRange) (abicalldata.ByteRange, error) {
+	out, err := mapRanges(state.ranges, func(r ByteRange) (ByteRange, error) {
 		if start+length > r.Size {
-			return abicalldata.ByteRange{}, fmt.Errorf("arg slot out of bounds for %d", argIndex)
+			return ByteRange{}, fmt.Errorf("arg slot out of bounds for %d", argIndex)
 		}
-		return abicalldata.ByteRange{
+		return ByteRange{
 			CallIndex: r.CallIndex,
 			Offset:    r.Offset + start,
 			Size:      length,
@@ -326,16 +324,16 @@ func (s argBytesDataStep) apply(payload *v3.CallsPayload, state *pathState) erro
 	if argType.T != abi.BytesTy && argType.T != abi.StringTy {
 		return fmt.Errorf("arg %s is not bytes/string (%s)", s.name, argType.String())
 	}
-	out, err := mapRanges(state.ranges, func(r abicalldata.ByteRange) (abicalldata.ByteRange, error) {
+	out, err := mapRanges(state.ranges, func(r ByteRange) (ByteRange, error) {
 		data, err := r.Slice(payload)
 		if err != nil {
-			return abicalldata.ByteRange{}, err
+			return ByteRange{}, err
 		}
-		start, length, err := abicalldata.CalldataBytesContent(data, method, argIndex)
+		start, length, err := CalldataBytesContent(data, method, argIndex)
 		if err != nil {
-			return abicalldata.ByteRange{}, err
+			return ByteRange{}, err
 		}
-		return abicalldata.ByteRange{
+		return ByteRange{
 			CallIndex: r.CallIndex,
 			Offset:    r.Offset + start,
 			Size:      length,
@@ -365,16 +363,16 @@ func (s argBytesDataIndexStep) apply(payload *v3.CallsPayload, state *pathState)
 	if argType.T != abi.BytesTy && argType.T != abi.StringTy {
 		return fmt.Errorf("arg %d is not bytes/string (%s)", argIndex, argType.String())
 	}
-	out, err := mapRanges(state.ranges, func(r abicalldata.ByteRange) (abicalldata.ByteRange, error) {
+	out, err := mapRanges(state.ranges, func(r ByteRange) (ByteRange, error) {
 		data, err := r.Slice(payload)
 		if err != nil {
-			return abicalldata.ByteRange{}, err
+			return ByteRange{}, err
 		}
-		start, length, err := abicalldata.CalldataBytesContent(data, method, argIndex)
+		start, length, err := CalldataBytesContent(data, method, argIndex)
 		if err != nil {
-			return abicalldata.ByteRange{}, err
+			return ByteRange{}, err
 		}
-		return abicalldata.ByteRange{
+		return ByteRange{
 			CallIndex: r.CallIndex,
 			Offset:    r.Offset + start,
 			Size:      length,
@@ -404,16 +402,16 @@ func (s argBytesEncodedStep) apply(payload *v3.CallsPayload, state *pathState) e
 	if argType.T != abi.BytesTy && argType.T != abi.StringTy {
 		return fmt.Errorf("arg %s is not bytes/string (%s)", s.name, argType.String())
 	}
-	out, err := mapRanges(state.ranges, func(r abicalldata.ByteRange) (abicalldata.ByteRange, error) {
+	out, err := mapRanges(state.ranges, func(r ByteRange) (ByteRange, error) {
 		data, err := r.Slice(payload)
 		if err != nil {
-			return abicalldata.ByteRange{}, err
+			return ByteRange{}, err
 		}
-		start, length, err := abicalldata.CalldataBytesEncoded(data, method, argIndex)
+		start, length, err := CalldataBytesEncoded(data, method, argIndex)
 		if err != nil {
-			return abicalldata.ByteRange{}, err
+			return ByteRange{}, err
 		}
-		return abicalldata.ByteRange{
+		return ByteRange{
 			CallIndex: r.CallIndex,
 			Offset:    r.Offset + start,
 			Size:      length,
@@ -444,26 +442,26 @@ func (s encodedCallDataStep) apply(payload *v3.CallsPayload, state *pathState) e
 	if len(state.ranges) == 0 {
 		return fmt.Errorf("encodedCallData step has no active ranges")
 	}
-	out, err := mapRanges(state.ranges, func(r abicalldata.ByteRange) (abicalldata.ByteRange, error) {
+	out, err := mapRanges(state.ranges, func(r ByteRange) (ByteRange, error) {
 		data, err := r.Slice(payload)
 		if err != nil {
-			return abicalldata.ByteRange{}, err
+			return ByteRange{}, err
 		}
 		layout, err := ParsePackedCalls(data)
 		if err != nil {
-			return abicalldata.ByteRange{}, err
+			return ByteRange{}, err
 		}
 		if s.index < 0 || s.index >= layout.NumCalls {
-			return abicalldata.ByteRange{}, fmt.Errorf("packed call index out of range: %d", s.index)
+			return ByteRange{}, fmt.Errorf("packed call index out of range: %d", s.index)
 		}
 		span := layout.CallData[s.index]
 		if span.Start < 0 || span.Len == 0 {
-			return abicalldata.ByteRange{}, fmt.Errorf("packed call %d has no calldata", s.index)
+			return ByteRange{}, fmt.Errorf("packed call %d has no calldata", s.index)
 		}
 		if span.Start > math.MaxInt-r.Offset {
-			return abicalldata.ByteRange{}, fmt.Errorf("packed call %d offset overflow", s.index)
+			return ByteRange{}, fmt.Errorf("packed call %d offset overflow", s.index)
 		}
-		return abicalldata.ByteRange{
+		return ByteRange{
 			CallIndex: r.CallIndex,
 			Offset:    r.Offset + span.Start,
 			Size:      span.Len,
@@ -483,24 +481,6 @@ func argIndexByName(method abi.Method, name string) (int, error) {
 		}
 	}
 	return -1, fmt.Errorf("arg not found: %s", name)
-}
-
-func isDynamicType(t abi.Type) bool {
-	switch t.T {
-	case abi.BytesTy, abi.StringTy, abi.SliceTy:
-		return true
-	case abi.ArrayTy:
-		return t.Size == 0 || isDynamicType(*t.Elem)
-	case abi.TupleTy:
-		for _, elem := range t.TupleElems {
-			if isDynamicType(*elem) {
-				return true
-			}
-		}
-		return false
-	default:
-		return false
-	}
 }
 
 func bytesEqual(a, b []byte) bool {

--- a/lib/abicalldata/path_test.go
+++ b/lib/abicalldata/path_test.go
@@ -1,4 +1,4 @@
-package malleable
+package abicalldata
 
 import (
 	"math/big"

--- a/lib/abicalldata/span.go
+++ b/lib/abicalldata/span.go
@@ -1,4 +1,4 @@
-package malleable
+package abicalldata
 
 type Span struct {
 	Start int

--- a/lib/hydrate/README.md
+++ b/lib/hydrate/README.md
@@ -2,7 +2,7 @@
 
 Build `hydratePayload` bytes for **HydrateProxy** (`hydrateExecute` / `hydrateExecuteAndSweep` in trails-contracts) by resolving patch targets with [`abicalldata`](https://github.com/0xsequence/go-sequence/tree/master/lib/abicalldata) **`Selector`** and **`ByteRange`** instead of hand-counting calldata offsets.
 
-`hydrate` depends only on `abicalldata` for selector types. The example below builds an `abicalldata.Selector` using `Path` from `lib/sapient/malleable`; fixed offsets can use `abicalldata.NewRangeSelector` instead.
+This package depends on **`abicalldata`** for selector types and for building selectors with **`abicalldata.NewPath()`** (or **`abicalldata.NewRangeSelector`** for fixed offsets).
 
 ## Usage
 
@@ -10,7 +10,7 @@ Build `hydratePayload` bytes for **HydrateProxy** (`hydrateExecute` / `hydrateEx
 payload := v3.NewCallsPayload(...)
 
 // Selector must resolve to exactly one range on the target call (same index as ForCall).
-permitOwner := malleable.NewPath().
+permitOwner := abicalldata.NewPath().
     CallData(0).
     ABI(trailsABI, "hydrateExecute").
     ArgBytesData("packedPayload").
@@ -47,7 +47,7 @@ calldata, err := hydrate.PackHydrateExecuteAndSweep(
 )
 ```
 
-If ABI parameters are unnamed, use index-based steps such as `ArgSlotIndex` / `ArgBytesDataIndex` when your path builder provides them.
+If ABI parameters are unnamed, use index-based steps such as **`ArgSlotIndex`** / **`ArgBytesDataIndex`** on **`abicalldata.NewPath()`** (see the abicalldata README).
 
 ## Call sections and ordering
 

--- a/lib/hydrate/builder.go
+++ b/lib/hydrate/builder.go
@@ -27,7 +27,7 @@ func SourceTxOrigin() AddrSource                { return AddrSource{kind: DataTx
 func SourceAddress(a common.Address) AddrSource { return AddrSource{kind: DataAnyAddress, addr: a} }
 
 // Builder constructs hydratePayload bytes for HydrateProxy using abicalldata.Selector
-// (calldata selectors: ABI paths via malleable.NewPath().AsSelector() in app code, fixed
+// (calldata selectors: ABI paths via abicalldata.NewPath().AsSelector() in app code, fixed
 // ranges via abicalldata.NewRangeSelector, etc.) so call-data offsets are not hand-computed.
 //
 // Sections are emitted in ascending call index order, which matches how HydrateProxy

--- a/lib/hydrate/builder_test.go
+++ b/lib/hydrate/builder_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/0xsequence/ethkit/go-ethereum/common"
 	v3 "github.com/0xsequence/go-sequence/core/v3"
 	"github.com/0xsequence/go-sequence/lib/abicalldata"
-	"github.com/0xsequence/go-sequence/lib/sapient/malleable"
 	"github.com/stretchr/testify/require"
 )
 
@@ -158,7 +157,7 @@ func TestBuilder_DataAddress_ArgSlotUsesRightAlignedAddressBytes(t *testing.T) {
 		big.NewInt(0),
 	)
 
-	ownerSelector := malleable.NewPath().
+	ownerSelector := abicalldata.NewPath().
 		CallData(0).
 		ABI(&ownerABI, "setOwner").
 		ArgSlot("owner").

--- a/lib/sapient/malleable/README.md
+++ b/lib/sapient/malleable/README.md
@@ -2,12 +2,14 @@
 
 Build MalleableSapient signatures by locating byte ranges in call data, and optionally compute the image hash.
 
+**ABI calldata paths** use **`abicalldata.NewPath()`** (see [`lib/abicalldata`](https://github.com/0xsequence/go-sequence/tree/master/lib/abicalldata)); this package supplies **`Builder`**, repeat constraints, and **`ComputeImageHash`**.
+
 ## Usage
 
 ```go
 payload := v3.NewCallsPayload(...)
 
-permitValue := malleable.NewPath().
+permitValue := abicalldata.NewPath().
     CallData(0).
     ABI(trailsABI, "hydrateExecute").
     ArgBytesData("packedPayload").
@@ -17,7 +19,7 @@ permitValue := malleable.NewPath().
     ArgSlot("value").
     AsSelector()
 
-transferValue := malleable.NewPath().
+transferValue := abicalldata.NewPath().
     CallData(0).
     ABI(trailsABI, "hydrateExecute").
     ArgBytesData("packedPayload").
@@ -35,7 +37,7 @@ b := malleable.NewBuilder(&payload, &malleable.BuilderOptions{
 b.Repeat(permitValue, transferValue) // repeat constraint
 
 // mark other malleable fields
-b.Malleable(malleable.NewPath().
+b.Malleable(abicalldata.NewPath().
     CallData(0).
     ABI(trailsABI, "hydrateExecute").
     ArgBytesData("packedPayload").
@@ -52,21 +54,14 @@ sig, _, err := b.Build()
 If ABI params are unnamed, use index-based selectors:
 
 ```go
-value := malleable.NewPath().
+value := abicalldata.NewPath().
     CallData(0).
     ABI(erc20ABI, "transferFrom").
     ArgSlotIndex(2).
     AsSelector()
 ```
 
-After any step that narrows the active range or descends into a new byte
-frame, ABI context is cleared. This includes steps like `.Slice(...)`,
-`.ArgBytesData(...)`, `.ArgBytesDataIndex(...)`, `.ArgBytesEncoded(...)`,
-`.EncodedCallsPayload()`, and `.EncodedCallData(...)`.
-
-Call `.ABI(...)` again before using `.ArgSlot(...)`, `.ArgSlotIndex(...)`,
-`.ArgBytesData(...)`, `.ArgBytesDataIndex(...)`, or `.ArgBytesEncoded(...)`
-against the new frame.
+Path semantics (when to rebind **`.ABI`** after nested steps) are documented in the **abicalldata** README.
 
 Compute the image hash:
 

--- a/lib/sapient/malleable/builder.go
+++ b/lib/sapient/malleable/builder.go
@@ -92,7 +92,7 @@ func (b *Builder) Build() ([]byte, *Plan, error) {
 		return nil, nil, fmt.Errorf("too many calls (%d): tindex is 7-bit", len(b.payload.Calls))
 	}
 
-	exByCall := make([][]Span, len(b.payload.Calls))
+	exByCall := make([][]abicalldata.Span, len(b.payload.Calls))
 
 	addExclude := func(r abicalldata.ByteRange) error {
 		if r.CallIndex < 0 || r.CallIndex >= len(b.payload.Calls) {
@@ -105,7 +105,7 @@ func (b *Builder) Build() ([]byte, *Plan, error) {
 		if r.Size > dataLen || r.Offset > dataLen-r.Size {
 			return fmt.Errorf("span out of bounds: offset=%d size=%d > %d", r.Offset, r.Size, dataLen)
 		}
-		exByCall[r.CallIndex] = append(exByCall[r.CallIndex], Span{Start: r.Offset, Len: r.Size})
+		exByCall[r.CallIndex] = append(exByCall[r.CallIndex], abicalldata.Span{Start: r.Offset, Len: r.Size})
 		return nil
 	}
 
@@ -180,12 +180,12 @@ func (b *Builder) Build() ([]byte, *Plan, error) {
 		cursor := 0
 		for _, s := range ex {
 			if cursor < s.Start {
-				statics = append(statics, SpanWithCall{CallIndex: t, Span: Span{Start: cursor, Len: s.Start - cursor}})
+				statics = append(statics, SpanWithCall{CallIndex: t, Span: abicalldata.Span{Start: cursor, Len: s.Start - cursor}})
 			}
 			cursor = max(cursor, s.Start+s.Len)
 		}
 		if cursor < length {
-			statics = append(statics, SpanWithCall{CallIndex: t, Span: Span{Start: cursor, Len: length - cursor}})
+			statics = append(statics, SpanWithCall{CallIndex: t, Span: abicalldata.Span{Start: cursor, Len: length - cursor}})
 		}
 	}
 
@@ -215,7 +215,7 @@ func (b *Builder) Build() ([]byte, *Plan, error) {
 
 type SpanWithCall struct {
 	CallIndex int
-	Span
+	abicalldata.Span
 }
 
 func (b *Builder) encodeStaticSections(statics []SpanWithCall) ([]StaticSection, error) {
@@ -252,12 +252,12 @@ func (b *Builder) encodeStaticSections(statics []SpanWithCall) ([]StaticSection,
 	return sections, nil
 }
 
-func mergeSpans(spans []Span) []Span {
+func mergeSpans(spans []abicalldata.Span) []abicalldata.Span {
 	if len(spans) == 0 {
 		return nil
 	}
 	sort.Slice(spans, func(i, j int) bool { return spans[i].Start < spans[j].Start })
-	out := []Span{spans[0]}
+	out := []abicalldata.Span{spans[0]}
 	for _, s := range spans[1:] {
 		last := &out[len(out)-1]
 		if s.Start <= last.Start+last.Len {


### PR DESCRIPTION
Removes the malleable dependency when using hydrate with paths. e.g.

```go
payload := v3.NewCallsPayload(...)

permitOwner := abicalldata.NewPath(). // <---- Was malleable.NewPath()
    CallData(0).
    ABI(trailsABI, "hydrateExecute").
    ArgBytesData("packedPayload").
    EncodedCallsPayload().
    EncodedCallData(0).
    ABI(erc2612ABI, "permit").
    ArgSlot("owner").
    AsSelector()
b := hydrate.NewBuilder(&payload)
if err := b.ForCall(0).DataAddress(permitOwner, hydrate.SourceSelf()); err != nil {
    return err
}
hydratePayload, err := b.Build()
if err != nil {
    return err
}
```